### PR TITLE
Fix TypeError: Argument 1 of Window.getComputedStyle does not implement interface Element.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,11 +36,32 @@ class InputTrigger extends Component {
 
     this.handleTrigger = this.handleTrigger.bind(this);
     this.resetState = this.resetState.bind(this);
-    this.element = this.props.elementRef;
+    this.findInput = this.findInput.bind(this);
   }
+
 
   componentDidMount() {
     this.props.endTrigger(this.resetState);
+    this.element = this.findInput();
+  }
+
+  findInput() {
+    if (this.props.getElement) {
+      return this.props.getElement(this);
+    }
+    if (this.childElemnt instanceof Element && ['INPUT', 'TEXTAREA'].find(tag => tag === this.childElemnt.tagName)) {
+      return this.childElemnt;
+    }
+    const inputs = this.div.getElementsByTagName('input');
+    if (inputs.length) {
+      return inputs[0];
+    }
+    const textareas = this.div.getElementsByTagName('textarea');
+    if (textareas.length) {
+      return textareas[0];
+    }
+    return null;// Would like to warn, but lint disallowed console logs.
+    // console.warn('Multiple or no inputs detected', inputs);
   }
 
   handleTrigger(event) {
@@ -109,7 +130,7 @@ class InputTrigger extends Component {
 
   render() {
     const {
-      elementRef,
+      getElement,
       children,
       trigger,
       onStart,
@@ -124,15 +145,18 @@ class InputTrigger extends Component {
         role="textbox"
         tabIndex={-1}
         onKeyDown={this.handleTrigger}
+        ref={(el) => {
+          this.div = el;
+        }}
         {...rest}
       >
         {
-          !elementRef
+          !getElement
             ? (
               React.Children.map(this.props.children, child => (
                 React.cloneElement(child, {
                   ref: (element) => {
-                    this.element = element;
+                    this.childElemnt = element;
                     if (typeof child.ref === 'function') {
                       child.ref(element);
                     }
@@ -161,7 +185,7 @@ InputTrigger.propTypes = {
   onType: PropTypes.func,
   endTrigger: PropTypes.func,
   children: PropTypes.element.isRequired,
-  elementRef: PropTypes.element,
+  getElement: PropTypes.func,
 };
 
 InputTrigger.defaultProps = {
@@ -175,7 +199,7 @@ InputTrigger.defaultProps = {
   onCancel: () => {},
   onType: () => {},
   endTrigger: () => {},
-  elementRef: null,
+  getElement: undefined,
 };
 
 export default InputTrigger;


### PR DESCRIPTION
Fix for issue #12  and likely #10 

The issue is that if textarea / input isn't a direct child to the component it will send a react component to getCaretCoordinates

Solution for getting the correct element, 
1st: with prop getter method getElement, 
2nd: Already existing method of children maping / cloning, do check for it being either a input text area
3ed: finding first occurrence of an input or textarea element.

I wanted to have some warning in case there's multple, but linting forbade it. Also linting didn't like Element being used before it was Defined, despite it being a preexisting definition...,


Also Why the timeouts with 0ms?
With my fork where I'm using quill, I need to add ~1-5 ms to have quill update the cursor positon before the triger evaluates the position, but I don't get a reason for it now. 